### PR TITLE
Remove a vestigial variable

### DIFF
--- a/src/main/java/org/embulk/input/CommandFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/CommandFileInputPlugin.java
@@ -42,11 +42,6 @@ public class CommandFileInputPlugin
         public BufferAllocator getBufferAllocator();
     }
 
-    public static final List<String> SHELL = ImmutableList.of(
-        // TODO use ["PowerShell.exe", "-Command"] on windows?
-        "sh", "-c"
-    );
-
     private final Logger logger = Exec.getLogger(getClass());
 
     @Override


### PR DESCRIPTION
Hi, thanks for the porting Windows supporting feature from embulk/embulk-output-command#1.
But I found that `SHELL` variable which is no longer used is left as-is.... :confounded: 
