### PR TITLE
Add Compatibility version to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ configurations {
     provided
 }
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 version = "0.1.4"
 
 dependencies {


### PR DESCRIPTION
Hi @frsyuki,
I think this is not built for java7 like below.
https://gist.github.com/civitaspo/03116a2efba55111149d

So, I add Compatibility version to build.gradle.
Please rebuild and release the new version?
