### PR TITLE
Remove lib/embulk/input/command.rb

### DIFF
--- a/lib/embulk/input/command.rb
+++ b/lib/embulk/input/command.rb
@@ -1,3 +1,0 @@
-Embulk::JavaPlugin.register_input(
-  "command", "org.embulk.input.CommandFileInputPlugin",
-  File.expand_path('../../../../classpath', __FILE__))


### PR DESCRIPTION
As it is now built based on `org.embulk.embulk-plugins`, it no longer needs the `.rb` file. Let's remove it.